### PR TITLE
Simplify project for Windows-only usage

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -184,28 +184,21 @@ class Program
         Task? monitorTask = null;
         if (windowHandle.HasValue)
         {
-            if (OperatingSystem.IsWindows())
+            monitorTask = Task.Run(async () =>
             {
-                monitorTask = Task.Run(async () =>
+                while (true)
                 {
-                    while (true)
+                    // ウィンドウが閉じられたらサーバも停止
+                    if (!IsWindow(windowHandle.Value))
                     {
-                        // ウィンドウが閉じられたらサーバも停止
-                        if (!IsWindow(windowHandle.Value))
-                        {
-                            Console.WriteLine("[INFO] ウィンドウが閉じられたためサーバーを終了します。");
-                            cts.Cancel();
-                            listener.Stop();
-                            break;
-                        }
-                        await Task.Delay(1500);
+                        Console.WriteLine("[INFO] ウィンドウが閉じられたためサーバーを終了します。");
+                        cts.Cancel();
+                        listener.Stop();
+                        break;
                     }
-                });
-            }
-            else
-            {
-                Console.WriteLine("[WARN] ウィンドウハンドル監視はWindowsでのみサポートされているため、この引数は無視されます。");
-            }
+                    await Task.Delay(1500);
+                }
+            });
         }
 
         try

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,6 +1,6 @@
 # HmMicroHttpServer
 
-軽量・高速なクロスプラットフォーム対応のAOTマイクロHTTPサーバーです。
+軽量・高速なAOTマイクロHTTPサーバーです。
 
 ## 概要
 
@@ -10,34 +10,30 @@
 
 ## 主な特徴
 
-- **クロスプラットフォーム**: Windows, macOS, Linux で動作します。
 - **.NET 9 AOT対応**: .NETランタイム不要の単一実行ファイルとしてビルド可能です。
 - **ディレクトリ指定**: 任意のディレクトリをWebルートとして公開できます。
 - **自動ポート選択**: 空いているポートを自動で検出し、`localhost` でリクエストを待ち受けます。
 - **SPAフォールバック**: リクエストされたファイルが見つからない場合、`index.html` を返すため、SPA（Single Page Application）のホスティングにも便利です。
 - **MIMEタイプ自動判定**: ファイルの拡張子に基づいて適切なMIMEタイプを返します。
-- **ウィンドウハンドル監視 (Windows限定)**: 指定したウィンドウが閉じると、サーバーも自動で終了する機能を持ちます。
+- **ウィンドウハンドル監視**: 指定したウィンドウが閉じると、サーバーも自動で終了する機能を持ちます。
 
 ## 使い方
 
 ### コマンドライン引数
 
 ```
-HmMicroHttpServer [公開ディレクトリ] [ウィンドウハンドル(Windows限定, 省略可)]
+HmMicroHttpServer.exe [公開ディレクトリ] [ウィンドウハンドル(省略可)]
 ```
 
 - **第1引数: `公開ディレクトリ` (省略可)**
   - 公開したいディレクトリのパスを指定します。
   - 省略した場合、実行ファイルと同じ階層にある `www` ディレクトリが公開対象となります。
 
-- **第2引数: `ウィンドウハンドル` (Windows限定, 省略可)**
+- **第2引数: `ウィンドウハンドル` (省略可)**
   - 監視対象のウィンドウハンドルを数値で指定します。
-  - この機能は **Windowsでのみ利用可能** です。指定されたウィンドウが閉じると、HTTPサーバーも自動的に終了します。
-  - 他のOSでこの引数を指定しても無視されます。
+  - 指定されたウィンドウが閉じると、HTTPサーバーも自動的に終了します。
 
 ### 実行例
-
-#### Windowsの場合
 
 ```powershell
 # www フォルダを公開
@@ -45,16 +41,6 @@ HmMicroHttpServer [公開ディレクトリ] [ウィンドウハンドル(Window
 
 # カレントディレクトリを公開
 .\HmMicroHttpServer.exe .
-```
-
-#### macOS / Linuxの場合
-
-```bash
-# www フォルダを公開
-./HmMicroHttpServer www
-
-# カレントディレクトリを公開
-./HmMicroHttpServer .
 ```
 
 ### サーバー起動後の表示
@@ -82,20 +68,7 @@ Serving C:\path\to\www
 dotnet publish -c Release
 ```
 
-ビルドが完了すると、`bin/Release/net9.0/publish/` ディレクトリ内に実行ファイルが生成されます。（Windowsの場合は `HmMicroHttpServer.exe`、Linux/macOSの場合は `HmMicroHttpServer`）
-
-### クロスコンパイル（他のOS向けの実行ファイルをビルドする場合）
-
-もし他のOS向けの実行ファイルをビルドしたい場合は、`-r <RID>`オプションで[ランタイム識別子](https://learn.microsoft.com/ja-jp/dotnet/core/rid-catalog)を指定します。
-
-```bash
-# 例: Windows x64向けにビルド
-dotnet publish -c Release -r win-x64
-
-# 例: Linux x64向けにビルド
-dotnet publish -c Release -r linux-x64
-```
-この場合、実行ファイルは `bin/Release/net9.0/<RID>/publish/` ディレクトリに生成されます。
+ビルドが完了すると、`bin/Release/net9.0/publish/` ディレクトリ内に `HmMicroHttpServer.exe` が生成されます。
 
 ## ライセンス
 


### PR DESCRIPTION
The application is intended to be used only on Windows. This commit removes cross-platform compatibility code and documentation.

- `Program.cs`: Removed `OperatingSystem.IsWindows()` check, as it is now redundant.
- `ReadMe.md`: Removed all mentions of macOS and Linux, including usage examples and build instructions for those platforms.